### PR TITLE
remove image and change links

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,16 +23,10 @@ export default function Home() {
   });
   return (
     <div>
-      {hello} <Link href="/about">About</Link>
       <br />
-      <Image
-        src={"/charlatte.jpeg"}
-        alt="charlatte car"
-        width="164"
-        height="164"
-      />
+      <Link href="/comic_pricing"> comic price estimation feature</Link>
       <br />
-      <Link href="/comic_pricing"> new new feature</Link>
+      coming soon: other media recommendations
     </div>
   );
 }


### PR DESCRIPTION
quick fix - removed image and cleaned up landing page so it's just the two things we were focused on.
right now the only link is actually the comic pricing page, as the recommendation stuff was all on another branch and hadn't been fully reviewed yet